### PR TITLE
[#13]:svarga:test, add transform fixture pack for coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,3 +44,9 @@ target_link_libraries(h5cpp
 include(GNUInstallDirs)
 install(TARGETS h5cpp DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES h5cpp.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+
+option(H5CPP_BUILD_TESTS "Build h5cpp-compiler fixture tests" ON)
+if(H5CPP_BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,32 @@
+set(STUB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/stub)
+set(GOLDEN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/golden)
+set(RUN_FIXTURE ${CMAKE_CURRENT_SOURCE_DIR}/run_fixture.cmake)
+
+set(FIXTURES
+  primitives
+  typedef
+  nested-ns
+  embedded-pod
+  array-of-arrays
+  ignored-non-pod
+  unreferenced
+  topological
+)
+
+function(add_h5cpp_fixture_test name)
+  add_test(
+    NAME h5cpp.${name}
+    COMMAND
+      ${CMAKE_COMMAND}
+        "-DH5CPP_BIN=$<TARGET_FILE:h5cpp>"
+        "-DFIXTURE=${CMAKE_CURRENT_SOURCE_DIR}/fixtures/${name}.cpp"
+        "-DSTUB_DIR=${STUB_DIR}"
+        "-DGOLDEN=${GOLDEN_DIR}/${name}.expected"
+        "-DOUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}"
+        -P "${RUN_FIXTURE}"
+  )
+endfunction()
+
+foreach(fixture IN LISTS FIXTURES)
+  add_h5cpp_fixture_test(${fixture})
+endforeach()

--- a/tests/fixtures/array-of-arrays.cpp
+++ b/tests/fixtures/array-of-arrays.cpp
@@ -1,0 +1,18 @@
+#include "h5cpp_stub.hpp"
+
+namespace sn {
+struct Cell {
+  float x;
+  float y;
+};
+
+struct Grid {
+  int  idx;
+  Cell field_05[3][8];
+};
+}
+
+void use() {
+  sn::Grid g;
+  h5::write(0, "p/array-of-arrays", g);
+}

--- a/tests/fixtures/embedded-pod.cpp
+++ b/tests/fixtures/embedded-pod.cpp
@@ -1,0 +1,20 @@
+#include "h5cpp_stub.hpp"
+
+namespace sn {
+struct Inner {
+  int    a;
+  double b;
+};
+
+struct Outer {
+  int   idx;
+  Inner inner_singleton;
+  Inner inner_array[4];
+  double field_02[3];
+};
+}
+
+void use() {
+  sn::Outer r;
+  h5::write(0, "p/embedded-pod", r);
+}

--- a/tests/fixtures/ignored-non-pod.cpp
+++ b/tests/fixtures/ignored-non-pod.cpp
@@ -1,0 +1,25 @@
+#include "h5cpp_stub.hpp"
+
+#include <string>
+#include <vector>
+
+namespace sn {
+struct Pod {
+  int    idx;
+  double value;
+};
+
+struct Container {
+  double                      idx;
+  std::string                 name;
+  std::vector<Pod>            items;
+};
+}
+
+void use() {
+  sn::Pod r;
+  h5::write(0, "p/pod", r);
+
+  sn::Container c;
+  h5::write(0, "p/container-should-be-skipped", c);
+}

--- a/tests/fixtures/nested-ns.cpp
+++ b/tests/fixtures/nested-ns.cpp
@@ -1,0 +1,17 @@
+#include "h5cpp_stub.hpp"
+
+namespace outer {
+namespace middle {
+namespace inner {
+struct Record {
+  int    idx;
+  double value;
+};
+}
+}
+}
+
+void use() {
+  outer::middle::inner::Record r;
+  h5::write(0, "p/nested-ns", r);
+}

--- a/tests/fixtures/primitives.cpp
+++ b/tests/fixtures/primitives.cpp
@@ -1,0 +1,25 @@
+#include "h5cpp_stub.hpp"
+
+namespace sn::typecheck {
+struct Record {
+  char           _char;
+  unsigned char  _uchar;
+  short          _short;
+  unsigned short _ushort;
+  int            _int;
+  unsigned int   _uint;
+  long           _long;
+  unsigned long  _ulong;
+  long long      _llong;
+  unsigned long long _ullong;
+  float          _float;
+  double         _double;
+  long double    _ldouble;
+  bool           _bool;
+};
+}
+
+void use() {
+  sn::typecheck::Record r;
+  h5::write(0, "p/primitives", r);
+}

--- a/tests/fixtures/topological.cpp
+++ b/tests/fixtures/topological.cpp
@@ -1,0 +1,31 @@
+#include "h5cpp_stub.hpp"
+
+namespace sn {
+
+struct Leaf {
+  int x;
+  int y;
+};
+
+struct LeafSibling {
+  float a;
+  float b;
+};
+
+struct Branch {
+  int  branch_idx;
+  Leaf leaves[4];
+};
+
+struct Root {
+  int         root_idx;
+  Branch      branches[3];
+  LeafSibling extras[2];
+};
+
+}
+
+void use() {
+  sn::Root r;
+  h5::write(0, "p/topological", r);
+}

--- a/tests/fixtures/typedef.cpp
+++ b/tests/fixtures/typedef.cpp
@@ -1,0 +1,17 @@
+#include "h5cpp_stub.hpp"
+
+typedef unsigned long long MyUInt;
+typedef double             MyDouble;
+
+namespace sn {
+struct Record {
+  MyUInt   idx;
+  MyUInt   aa;
+  MyDouble value;
+};
+}
+
+void use() {
+  sn::Record r;
+  h5::write(0, "p/typedef", r);
+}

--- a/tests/fixtures/unreferenced.cpp
+++ b/tests/fixtures/unreferenced.cpp
@@ -1,0 +1,22 @@
+#include "h5cpp_stub.hpp"
+
+namespace sn {
+struct Referenced {
+  int    idx;
+  double value;
+};
+
+struct UnreferencedA {
+  long  ignored_field_a;
+  float ignored_field_b;
+};
+
+struct UnreferencedB {
+  char  also_ignored;
+};
+}
+
+void use() {
+  sn::Referenced r;
+  h5::write(0, "p/referenced", r);
+}

--- a/tests/run_fixture.cmake
+++ b/tests/run_fixture.cmake
@@ -1,0 +1,65 @@
+# Drive a single fixture run.
+#
+# Inputs (passed via -D on the cmake -P invocation):
+#   H5CPP_BIN  : absolute path to the h5cpp executable
+#   FIXTURE    : absolute path to the fixture source file (.cpp)
+#   STUB_DIR   : include directory containing tests/stub/h5cpp_stub.hpp
+#   GOLDEN     : absolute path to the golden expected output (may not exist)
+#   OUTPUT_DIR : directory for the observed output
+#
+# Behaviour:
+#   - Runs h5cpp on the fixture, capturing the generated header.
+#   - Normalises the random include guard so the output is byte-stable.
+#   - If GOLDEN exists, diffs against it; mismatch fails the test.
+#   - If GOLDEN does not exist, prints a hint with the observed path and passes.
+#     This lets the first CI run establish a baseline that can be reviewed and
+#     committed as golden in a follow-up.
+
+cmake_minimum_required(VERSION 3.14)
+
+get_filename_component(fixture_name "${FIXTURE}" NAME_WE)
+set(observed "${OUTPUT_DIR}/${fixture_name}.observed")
+
+execute_process(
+  COMMAND
+    "${H5CPP_BIN}"
+    "${FIXTURE}"
+    --
+    -std=c++17
+    "-I${STUB_DIR}"
+    "-D${observed}"
+  RESULT_VARIABLE rc
+  OUTPUT_VARIABLE tool_stdout
+  ERROR_VARIABLE  tool_stderr
+)
+
+if(NOT rc EQUAL 0)
+  message(FATAL_ERROR
+    "h5cpp exit ${rc} on ${fixture_name}\n"
+    "--- stdout ---\n${tool_stdout}\n"
+    "--- stderr ---\n${tool_stderr}")
+endif()
+
+if(NOT EXISTS "${observed}")
+  message(FATAL_ERROR "h5cpp produced no output for ${fixture_name} at ${observed}")
+endif()
+
+file(READ "${observed}" content)
+string(REGEX REPLACE
+  "H5CPP_GUARD_[A-Za-z][A-Za-z][A-Za-z][A-Za-z][A-Za-z]"
+  "H5CPP_GUARD_XXXXX"
+  content "${content}")
+file(WRITE "${observed}" "${content}")
+
+if(EXISTS "${GOLDEN}")
+  file(READ "${GOLDEN}" expected)
+  if(NOT "${content}" STREQUAL "${expected}")
+    message(FATAL_ERROR
+      "Golden mismatch for ${fixture_name}\n"
+      "  observed: ${observed}\n"
+      "  golden:   ${GOLDEN}\n"
+      "Refresh by copying observed over golden after manual review.")
+  endif()
+else()
+  message(STATUS "No golden for ${fixture_name}; baseline observation written to ${observed}")
+endif()

--- a/tests/stub/h5cpp_stub.hpp
+++ b/tests/stub/h5cpp_stub.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace h5 {
+using hid_t = long;
+using fd_t = long;
+
+template <class T> hid_t write(hid_t, const std::string&, const T&)  { return 0; }
+template <class T> hid_t read (hid_t, const std::string&)            { return 0; }
+template <class T> hid_t create(hid_t, const std::string&)           { return 0; }
+template <class T> hid_t append(hid_t, const std::string&, const T&) { return 0; }
+
+template <class T> hid_t awrite(hid_t, const std::string&, const T&) { return 0; }
+template <class T> hid_t aread (hid_t, const std::string&)           { return 0; }
+template <class T> hid_t acreate(hid_t, const std::string&)          { return 0; }
+}


### PR DESCRIPTION
## Summary

Add eight fixtures covering every documented AST-visitor transform path, plus a CTest harness that runs `h5cpp` on each fixture and (optionally) diffs against a golden output. First step toward the 94% line-coverage target on `src/`.

Closes #13.

## What's here

| Fixture | Coverage path |
|---|---|
| `primitives.cpp` | Single POD with all C primitive types (README's `typecheck::Record`) |
| `typedef.cpp` | Typedef'd primitives propagated through `h5::write<T>` |
| `nested-ns.cpp` | Struct inside a three-level namespace |
| `embedded-pod.cpp` | POD with singleton + array embedded-POD fields |
| `array-of-arrays.cpp` | 2D POD array field (README's `field_05[3][8]`) |
| `ignored-non-pod.cpp` | `std::string` / `std::vector` member; must be skipped |
| `unreferenced.cpp` | Struct never touched by an `h5::` operator; must be ignored |
| `topological.cpp` | Multi-level dependency chain with parallel leaves; exercises emission order |

Each fixture is a `.cpp` translation unit that includes a minimal `tests/stub/h5cpp_stub.hpp` providing template declarations for `h5::write/read/create/append/awrite/aread/acreate`. The tool's AST matcher fires on the instantiated `h5::write<T>(...)` call.

## Harness

`tests/CMakeLists.txt` registers one CTest per fixture. `tests/run_fixture.cmake` drives each run:

1. Invokes `h5cpp <fixture>.cpp -- -std=c++17 -I<stub> -D<observed>`.
2. Normalises the random `H5CPP_GUARD_<5 random chars>` include guard the tool emits so output is byte-stable.
3. If `tests/golden/<name>.expected` exists → diffs; mismatch fails the test.
4. If no golden exists → prints the observed path and passes. Lets the first CI run establish a baseline without locking in an unreviewed format.

Top-level `CMakeLists.txt` adds `H5CPP_BUILD_TESTS` option (default ON) plus `enable_testing()` + `add_subdirectory(tests)`.

## Goldens are deferred to a follow-up

The tool's emission format is currently the legacy `h5::register_struct<T>` form (per `src/producer_h5.hpp`). Issue #9 will rewrite this to emit `compiler_meta_t<T>` / `is_reflected_compound_t<T>` instead. Locking in goldens now would force a churn-y rewrite of all eight `.expected` files when #9 lands.

**Plan:** first CI run after this PR + #12 merges publishes observed outputs as artifacts. Goldens are reviewed and committed in a small follow-up commit once the baseline format is stable. Coverage from the AST walk is captured immediately because every fixture runs the tool to completion.

## Test plan

- [ ] CI builds the `h5cpp` target on all 12 matrix cells (depends on #12).
- [ ] `ctest` discovers and runs all 8 fixture tests.
- [ ] Each fixture run produces a `${fixture}.observed` file in the build dir.
- [ ] Codecov reports ≥ 94% line coverage on `src/` after PR #11 rebases on top of this. If short, the gap is documented and goldens are extended.

## Dependencies

- **Blocked by:** #12 (PR #15) — without the LLVM toolchain install the tool doesn't build, so ctest has nothing to run.
- **Unblocks:** PR #11 rebase (codecov plumbing) and #14 (sanitizer jobs).

## Conventions

- Branch cut from `staging`. ✓
- PR targets `staging`. ✓
- Two commits: `[#13]:svarga:test, ...` and `[#13]:svarga:build, ...`.

## Note on fixture extension

Issue #13 spec says `.hpp`; harness uses `.cpp` because the tool consumes translation units, not standalone headers. Adjustment documented here; functional intent unchanged.