### PR TITLE
[#13]:svarga:test, add transform fixture pack for coverage

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,9 @@ set(FIXTURES
   ignored-non-pod
   unreferenced
   topological
+  enum-member
+  multi-array
+  inheritance
 )
 
 function(add_h5cpp_fixture_test name)

--- a/tests/fixtures/enum-member.cpp
+++ b/tests/fixtures/enum-member.cpp
@@ -1,0 +1,21 @@
+#include "h5cpp_stub.hpp"
+
+namespace sn {
+
+enum class Color : int { Red = 0, Green = 1, Blue = 2 };
+
+// Struct whose only field is an enum. The struct itself satisfies isPOD()
+// (enum is a scalar type), so the compiler will enter the reflect path, but
+// the enum field resolves to <unknown_type> inside utils::get_type_name.
+// This exercises the type::invalid branch in utils::as<utils::type>().
+struct Palette {
+  Color primary;
+  Color secondary;
+};
+
+}
+
+void use() {
+  sn::Palette p;
+  h5::write(0, "p/enum-member", p);
+}

--- a/tests/fixtures/inheritance.cpp
+++ b/tests/fixtures/inheritance.cpp
@@ -1,0 +1,27 @@
+#include "h5cpp_stub.hpp"
+
+namespace sn {
+
+// Base struct: satisfies isPOD() and will be reflected when referenced directly.
+struct Base {
+  int    id;
+  double value;
+};
+
+// Derived struct: has a base class, so it is NOT POD (C++17 standard-layout
+// rule §9/7 requires no base class for POD structs). The compiler's isPOD()
+// guard skips it even though all its new fields are scalar.
+// Only Base is reflected; Derived is ignored.
+struct Derived : Base {
+  float extra;
+};
+
+}
+
+void use() {
+  sn::Base b;
+  h5::write(0, "p/base", b);
+
+  sn::Derived d;
+  h5::write(0, "p/derived-should-be-skipped", d);
+}

--- a/tests/fixtures/multi-array.cpp
+++ b/tests/fixtures/multi-array.cpp
@@ -1,0 +1,20 @@
+#include "h5cpp_stub.hpp"
+
+namespace sn {
+
+// Struct with a multi-dimensional C array of a primitive type.
+// Distinct from array-of-arrays (which has arrays of struct-typed members):
+// here the element type is a plain float, exercising the array path where
+// the inner element resolves to type::builtin rather than type::record.
+struct Matrix {
+  int   rows;
+  int   cols;
+  float data[4][4];
+};
+
+}
+
+void use() {
+  sn::Matrix m;
+  h5::write(0, "p/multi-array", m);
+}


### PR DESCRIPTION
## Summary

- Adds three new CTest fixtures that exercise previously uncovered AST visitor branches: scoped enum fields, 2D C arrays, and struct inheritance (POD base reflected, non-POD derived skipped)
- No golden files committed — CI establishes baselines on first green run, then golden files are committed in a follow-up

## Fixtures added

| File | Exercises |
|---|---|
| `tests/fixtures/enum-member.cpp` | Unknown field type / scoped enum branch |
| `tests/fixtures/multi-array.cpp` | 2D C array field (`float data[4][4]`) |
| `tests/fixtures/inheritance.cpp` | Base (POD, reflected) + Derived (non-POD, skipped) |

## Test plan

- [ ] CI builds and all 13 matrix cells pass
- [ ] Coverage job shows increased line coverage after golden files are added
- [ ] No regressions in existing 8 fixtures

Closes #13