### PR TITLE
[#36]:svarga:fix, regenerate h5 fixture goldens after producer output change

### DIFF
--- a/tests/golden/h5_chunk.expected
+++ b/tests/golden/h5_chunk.expected
@@ -1,75 +1,74 @@
 #pragma once
 
-#include <hdf5.h>
 #include <h5cpp/all>
-
 namespace h5::generated::sn__sensor__chunked_t_ {
-
-struct row_t {
-    unsigned long long timestamp_ns;
-    hvl_t    samples;
-};
-
-inline hid_t compound_type() {
-    static const hid_t ct = []{
-        hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
-        hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
-        H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
-        H5Tinsert(ct, "samples", HOFFSET(row_t, samples), v_samples);
+    struct row_t {
+        unsigned long long timestamp_ns;
+        hvl_t    samples;
+    };
+    inline hid_t compound_type() {
+        static const hid_t ct = []{
+            hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
+            hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
+            H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
+            H5Tinsert(ct, "samples", HOFFSET(row_t, samples), v_samples);
+            return ct;
+        }();
         return ct;
-    }();
-    return ct;
-}
-
+    }
 } // namespace h5::generated::sn__sensor__chunked_t_
 
 namespace h5 {
-template<> inline h5::ds_t scatter<sn::sensor::chunked_t>(
-    hid_t fd, const std::string& path, const sn::sensor::chunked_t& obj) {
-    using namespace ::h5::generated::sn__sensor__chunked_t_;
-    h5::ds_t ds;
-    h5::mute();
-    bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
-    h5::unmute();
-    if (exists) {
-        ds = h5::open(fd, path, h5::default_dapl);
-    } else {
-        h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
-        hsize_t chunk = 256;
-        H5Pset_chunk(dcpl, 1, &chunk);
-        hsize_t cur = 0;
-        hsize_t max = H5S_UNLIMITED;
-        hid_t space = H5Screate_simple(1, &cur, &max);
-        ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
-            h5::default_lcpl, dcpl, h5::default_dapl);
+    template<> inline h5::ds_t scatter<sn::sensor::chunked_t>(
+        hid_t fd, const std::string& path, const sn::sensor::chunked_t& obj) {
+        using namespace ::h5::generated::sn__sensor__chunked_t_;
+        h5::ds_t ds;
+        h5::mute();
+        bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
+        h5::unmute();
+        if (!exists) {
+            h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
+            hsize_t chunk = 256;
+            H5Pset_chunk(dcpl, 1, &chunk);
+            hsize_t cur = 0;
+            hsize_t max = H5S_UNLIMITED;
+            hid_t space = H5Screate_simple(1, &cur, &max);
+            ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
+                h5::default_lcpl, dcpl, h5::default_dapl);
+        } else ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t row = h5::detail::next_row(ds);
+        hsize_t samples_len = obj.samples.size();
+        auto* samples_ptr = obj.samples.data();
+        row_t r{
+            obj.timestamp_ns,
+            hvl_t{samples_len, (void*)samples_ptr}
+        };
+        herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
+        (void)err;
+        return ds;
     }
-    hsize_t row = h5::detail::next_row(ds);
-    hsize_t samples_len = obj.samples.size();
-    auto* samples_ptr = obj.samples.data();
-    row_t r{
-        obj.timestamp_ns,
-        hvl_t{samples_len, (void*)samples_ptr}
-    };
-    herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
-    (void)err;
-    return ds;
-}
 } // namespace h5
 
 namespace h5 {
-template<> inline void gather<sn::sensor::chunked_t>(
-    hid_t fd, const std::string& path, sn::sensor::chunked_t& obj) {
-    using namespace ::h5::generated::sn__sensor__chunked_t_;
-    h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
-    hsize_t nrows = h5::detail::next_row(ds);
-    if (nrows == 0) return;
-    row_t r{};
-    herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
-    (void)err;
-    obj.timestamp_ns = r.timestamp_ns;
-    obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
-    H5Treclaim(compound_type(), H5S_ALL, H5P_DEFAULT, &r);
-}
+    template<> inline void gather<sn::sensor::chunked_t>(
+        hid_t fd, const std::string& path, sn::sensor::chunked_t& obj) {
+        using namespace ::h5::generated::sn__sensor__chunked_t_;
+        h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t nrows = h5::detail::next_row(ds);
+        if (nrows == 0) return;
+        row_t r{};
+        herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
+        (void)err;
+        obj.timestamp_ns = r.timestamp_ns;
+        obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
+        hid_t reclaim_space = H5Screate(H5S_SCALAR);
+        #if H5_VERSION_GE(1,12,0)
+            H5Treclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #else
+            H5Dvlen_reclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #endif
+        H5Sclose(reclaim_space);
+    }
 } // namespace h5
 
 H5CPP_REGISTER_SCATTER(sn::sensor::chunked_t);

--- a/tests/golden/h5_chunk_compress.expected
+++ b/tests/golden/h5_chunk_compress.expected
@@ -1,76 +1,75 @@
 #pragma once
 
-#include <hdf5.h>
 #include <h5cpp/all>
-
 namespace h5::generated::sn__sensor__chunked_compressed_t_ {
-
-struct row_t {
-    unsigned long long timestamp_ns;
-    hvl_t    samples;
-};
-
-inline hid_t compound_type() {
-    static const hid_t ct = []{
-        hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
-        hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
-        H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
-        H5Tinsert(ct, "samples", HOFFSET(row_t, samples), v_samples);
+    struct row_t {
+        unsigned long long timestamp_ns;
+        hvl_t    samples;
+    };
+    inline hid_t compound_type() {
+        static const hid_t ct = []{
+            hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
+            hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
+            H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
+            H5Tinsert(ct, "samples", HOFFSET(row_t, samples), v_samples);
+            return ct;
+        }();
         return ct;
-    }();
-    return ct;
-}
-
+    }
 } // namespace h5::generated::sn__sensor__chunked_compressed_t_
 
 namespace h5 {
-template<> inline h5::ds_t scatter<sn::sensor::chunked_compressed_t>(
-    hid_t fd, const std::string& path, const sn::sensor::chunked_compressed_t& obj) {
-    using namespace ::h5::generated::sn__sensor__chunked_compressed_t_;
-    h5::ds_t ds;
-    h5::mute();
-    bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
-    h5::unmute();
-    if (exists) {
-        ds = h5::open(fd, path, h5::default_dapl);
-    } else {
-        h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
-        hsize_t chunk = 128;
-        H5Pset_chunk(dcpl, 1, &chunk);
-        H5Pset_deflate(dcpl, 9);
-        hsize_t cur = 0;
-        hsize_t max = H5S_UNLIMITED;
-        hid_t space = H5Screate_simple(1, &cur, &max);
-        ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
-            h5::default_lcpl, dcpl, h5::default_dapl);
+    template<> inline h5::ds_t scatter<sn::sensor::chunked_compressed_t>(
+        hid_t fd, const std::string& path, const sn::sensor::chunked_compressed_t& obj) {
+        using namespace ::h5::generated::sn__sensor__chunked_compressed_t_;
+        h5::ds_t ds;
+        h5::mute();
+        bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
+        h5::unmute();
+        if (!exists) {
+            h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
+            hsize_t chunk = 128;
+            H5Pset_chunk(dcpl, 1, &chunk);
+            H5Pset_deflate(dcpl, 9);
+            hsize_t cur = 0;
+            hsize_t max = H5S_UNLIMITED;
+            hid_t space = H5Screate_simple(1, &cur, &max);
+            ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
+                h5::default_lcpl, dcpl, h5::default_dapl);
+        } else ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t row = h5::detail::next_row(ds);
+        hsize_t samples_len = obj.samples.size();
+        auto* samples_ptr = obj.samples.data();
+        row_t r{
+            obj.timestamp_ns,
+            hvl_t{samples_len, (void*)samples_ptr}
+        };
+        herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
+        (void)err;
+        return ds;
     }
-    hsize_t row = h5::detail::next_row(ds);
-    hsize_t samples_len = obj.samples.size();
-    auto* samples_ptr = obj.samples.data();
-    row_t r{
-        obj.timestamp_ns,
-        hvl_t{samples_len, (void*)samples_ptr}
-    };
-    herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
-    (void)err;
-    return ds;
-}
 } // namespace h5
 
 namespace h5 {
-template<> inline void gather<sn::sensor::chunked_compressed_t>(
-    hid_t fd, const std::string& path, sn::sensor::chunked_compressed_t& obj) {
-    using namespace ::h5::generated::sn__sensor__chunked_compressed_t_;
-    h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
-    hsize_t nrows = h5::detail::next_row(ds);
-    if (nrows == 0) return;
-    row_t r{};
-    herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
-    (void)err;
-    obj.timestamp_ns = r.timestamp_ns;
-    obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
-    H5Treclaim(compound_type(), H5S_ALL, H5P_DEFAULT, &r);
-}
+    template<> inline void gather<sn::sensor::chunked_compressed_t>(
+        hid_t fd, const std::string& path, sn::sensor::chunked_compressed_t& obj) {
+        using namespace ::h5::generated::sn__sensor__chunked_compressed_t_;
+        h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t nrows = h5::detail::next_row(ds);
+        if (nrows == 0) return;
+        row_t r{};
+        herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
+        (void)err;
+        obj.timestamp_ns = r.timestamp_ns;
+        obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
+        hid_t reclaim_space = H5Screate(H5S_SCALAR);
+        #if H5_VERSION_GE(1,12,0)
+            H5Treclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #else
+            H5Dvlen_reclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #endif
+        H5Sclose(reclaim_space);
+    }
 } // namespace h5
 
 H5CPP_REGISTER_SCATTER(sn::sensor::chunked_compressed_t);

--- a/tests/golden/h5_compress.expected
+++ b/tests/golden/h5_compress.expected
@@ -1,76 +1,75 @@
 #pragma once
 
-#include <hdf5.h>
 #include <h5cpp/all>
-
 namespace h5::generated::sn__sensor__compressed_t_ {
-
-struct row_t {
-    unsigned long long timestamp_ns;
-    hvl_t    samples;
-};
-
-inline hid_t compound_type() {
-    static const hid_t ct = []{
-        hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
-        hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
-        H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
-        H5Tinsert(ct, "samples", HOFFSET(row_t, samples), v_samples);
+    struct row_t {
+        unsigned long long timestamp_ns;
+        hvl_t    samples;
+    };
+    inline hid_t compound_type() {
+        static const hid_t ct = []{
+            hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
+            hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
+            H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
+            H5Tinsert(ct, "samples", HOFFSET(row_t, samples), v_samples);
+            return ct;
+        }();
         return ct;
-    }();
-    return ct;
-}
-
+    }
 } // namespace h5::generated::sn__sensor__compressed_t_
 
 namespace h5 {
-template<> inline h5::ds_t scatter<sn::sensor::compressed_t>(
-    hid_t fd, const std::string& path, const sn::sensor::compressed_t& obj) {
-    using namespace ::h5::generated::sn__sensor__compressed_t_;
-    h5::ds_t ds;
-    h5::mute();
-    bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
-    h5::unmute();
-    if (exists) {
-        ds = h5::open(fd, path, h5::default_dapl);
-    } else {
-        h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
-        hsize_t chunk = 64;
-        H5Pset_chunk(dcpl, 1, &chunk);
-        H5Pset_deflate(dcpl, 6);
-        hsize_t cur = 0;
-        hsize_t max = H5S_UNLIMITED;
-        hid_t space = H5Screate_simple(1, &cur, &max);
-        ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
-            h5::default_lcpl, dcpl, h5::default_dapl);
+    template<> inline h5::ds_t scatter<sn::sensor::compressed_t>(
+        hid_t fd, const std::string& path, const sn::sensor::compressed_t& obj) {
+        using namespace ::h5::generated::sn__sensor__compressed_t_;
+        h5::ds_t ds;
+        h5::mute();
+        bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
+        h5::unmute();
+        if (!exists) {
+            h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
+            hsize_t chunk = 64;
+            H5Pset_chunk(dcpl, 1, &chunk);
+            H5Pset_deflate(dcpl, 6);
+            hsize_t cur = 0;
+            hsize_t max = H5S_UNLIMITED;
+            hid_t space = H5Screate_simple(1, &cur, &max);
+            ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
+                h5::default_lcpl, dcpl, h5::default_dapl);
+        } else ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t row = h5::detail::next_row(ds);
+        hsize_t samples_len = obj.samples.size();
+        auto* samples_ptr = obj.samples.data();
+        row_t r{
+            obj.timestamp_ns,
+            hvl_t{samples_len, (void*)samples_ptr}
+        };
+        herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
+        (void)err;
+        return ds;
     }
-    hsize_t row = h5::detail::next_row(ds);
-    hsize_t samples_len = obj.samples.size();
-    auto* samples_ptr = obj.samples.data();
-    row_t r{
-        obj.timestamp_ns,
-        hvl_t{samples_len, (void*)samples_ptr}
-    };
-    herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
-    (void)err;
-    return ds;
-}
 } // namespace h5
 
 namespace h5 {
-template<> inline void gather<sn::sensor::compressed_t>(
-    hid_t fd, const std::string& path, sn::sensor::compressed_t& obj) {
-    using namespace ::h5::generated::sn__sensor__compressed_t_;
-    h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
-    hsize_t nrows = h5::detail::next_row(ds);
-    if (nrows == 0) return;
-    row_t r{};
-    herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
-    (void)err;
-    obj.timestamp_ns = r.timestamp_ns;
-    obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
-    H5Treclaim(compound_type(), H5S_ALL, H5P_DEFAULT, &r);
-}
+    template<> inline void gather<sn::sensor::compressed_t>(
+        hid_t fd, const std::string& path, sn::sensor::compressed_t& obj) {
+        using namespace ::h5::generated::sn__sensor__compressed_t_;
+        h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t nrows = h5::detail::next_row(ds);
+        if (nrows == 0) return;
+        row_t r{};
+        herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
+        (void)err;
+        obj.timestamp_ns = r.timestamp_ns;
+        obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
+        hid_t reclaim_space = H5Screate(H5S_SCALAR);
+        #if H5_VERSION_GE(1,12,0)
+            H5Treclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #else
+            H5Dvlen_reclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #endif
+        H5Sclose(reclaim_space);
+    }
 } // namespace h5
 
 H5CPP_REGISTER_SCATTER(sn::sensor::compressed_t);

--- a/tests/golden/h5_ignore.expected
+++ b/tests/golden/h5_ignore.expected
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <hdf5.h>
 #include <h5cpp/all>
-
 namespace h5 {
     template<> hid_t inline register_struct<session_t>(){
 

--- a/tests/golden/h5_metadata.expected
+++ b/tests/golden/h5_metadata.expected
@@ -1,78 +1,77 @@
 #pragma once
 
-#include <hdf5.h>
 #include <h5cpp/all>
-
 // doc: "Sensor session data"
 // alias: "Session"
 // version: "1"
 namespace h5::generated::Session_ {
-
-struct row_t {
-    unsigned long long timestamp_ns;
-    hvl_t    samples;
-};
-
-inline hid_t compound_type() {
-    static const hid_t ct = []{
-        hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
-        hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
-        H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
-        H5Tinsert(ct, "samples", HOFFSET(row_t, samples), v_samples);
+    struct row_t {
+        unsigned long long timestamp_ns;
+        hvl_t    samples;
+    };
+    inline hid_t compound_type() {
+        static const hid_t ct = []{
+            hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
+            hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
+            H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
+            H5Tinsert(ct, "samples", HOFFSET(row_t, samples), v_samples);
+            return ct;
+        }();
         return ct;
-    }();
-    return ct;
-}
-
+    }
 } // namespace h5::generated::Session_
 
 namespace h5 {
-template<> inline h5::ds_t scatter<sn::sensor::metadata_t>(
-    hid_t fd, const std::string& path, const sn::sensor::metadata_t& obj) {
-    using namespace ::h5::generated::Session_;
-    h5::ds_t ds;
-    h5::mute();
-    bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
-    h5::unmute();
-    if (exists) {
-        ds = h5::open(fd, path, h5::default_dapl);
-    } else {
-        h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
-        hsize_t chunk = 64;
-        H5Pset_chunk(dcpl, 1, &chunk);
-        hsize_t cur = 0;
-        hsize_t max = H5S_UNLIMITED;
-        hid_t space = H5Screate_simple(1, &cur, &max);
-        ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
-            h5::default_lcpl, dcpl, h5::default_dapl);
+    template<> inline h5::ds_t scatter<sn::sensor::metadata_t>(
+        hid_t fd, const std::string& path, const sn::sensor::metadata_t& obj) {
+        using namespace ::h5::generated::Session_;
+        h5::ds_t ds;
+        h5::mute();
+        bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
+        h5::unmute();
+        if (!exists) {
+            h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
+            hsize_t chunk = 64;
+            H5Pset_chunk(dcpl, 1, &chunk);
+            hsize_t cur = 0;
+            hsize_t max = H5S_UNLIMITED;
+            hid_t space = H5Screate_simple(1, &cur, &max);
+            ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
+                h5::default_lcpl, dcpl, h5::default_dapl);
+        } else ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t row = h5::detail::next_row(ds);
+        hsize_t samples_len = obj.samples.size();
+        auto* samples_ptr = obj.samples.data();
+        row_t r{
+            obj.timestamp_ns,
+            hvl_t{samples_len, (void*)samples_ptr}
+        };
+        herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
+        (void)err;
+        return ds;
     }
-    hsize_t row = h5::detail::next_row(ds);
-    hsize_t samples_len = obj.samples.size();
-    auto* samples_ptr = obj.samples.data();
-    row_t r{
-        obj.timestamp_ns,
-        hvl_t{samples_len, (void*)samples_ptr}
-    };
-    herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
-    (void)err;
-    return ds;
-}
 } // namespace h5
 
 namespace h5 {
-template<> inline void gather<sn::sensor::metadata_t>(
-    hid_t fd, const std::string& path, sn::sensor::metadata_t& obj) {
-    using namespace ::h5::generated::Session_;
-    h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
-    hsize_t nrows = h5::detail::next_row(ds);
-    if (nrows == 0) return;
-    row_t r{};
-    herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
-    (void)err;
-    obj.timestamp_ns = r.timestamp_ns;
-    obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
-    H5Treclaim(compound_type(), H5S_ALL, H5P_DEFAULT, &r);
-}
+    template<> inline void gather<sn::sensor::metadata_t>(
+        hid_t fd, const std::string& path, sn::sensor::metadata_t& obj) {
+        using namespace ::h5::generated::Session_;
+        h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t nrows = h5::detail::next_row(ds);
+        if (nrows == 0) return;
+        row_t r{};
+        herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
+        (void)err;
+        obj.timestamp_ns = r.timestamp_ns;
+        obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
+        hid_t reclaim_space = H5Screate(H5S_SCALAR);
+        #if H5_VERSION_GE(1,12,0)
+            H5Treclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #else
+            H5Dvlen_reclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #endif
+        H5Sclose(reclaim_space);
+    }
 } // namespace h5
 
 H5CPP_REGISTER_SCATTER(sn::sensor::metadata_t);

--- a/tests/golden/h5_name.expected
+++ b/tests/golden/h5_name.expected
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <hdf5.h>
 #include <h5cpp/all>
-
 namespace h5 {
     template<> hid_t inline register_struct<sensor_reading_t>(){
 

--- a/tests/golden/h5_name_all.expected
+++ b/tests/golden/h5_name_all.expected
@@ -1,75 +1,74 @@
 #pragma once
 
-#include <hdf5.h>
 #include <h5cpp/all>
-
 namespace h5::generated::sn__sensor__name_all_t_ {
-
-struct row_t {
-    unsigned long long timestamp_ns;
-    hvl_t    samples;
-};
-
-inline hid_t compound_type() {
-    static const hid_t ct = []{
-        hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
-        hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
-        H5Tinsert(ct, "pfx_timestamp_ns_sfx", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
-        H5Tinsert(ct, "pfx_samples_sfx", HOFFSET(row_t, samples), v_samples);
+    struct row_t {
+        unsigned long long timestamp_ns;
+        hvl_t    samples;
+    };
+    inline hid_t compound_type() {
+        static const hid_t ct = []{
+            hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
+            hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
+            H5Tinsert(ct, "pfx_timestamp_ns_sfx", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
+            H5Tinsert(ct, "pfx_samples_sfx", HOFFSET(row_t, samples), v_samples);
+            return ct;
+        }();
         return ct;
-    }();
-    return ct;
-}
-
+    }
 } // namespace h5::generated::sn__sensor__name_all_t_
 
 namespace h5 {
-template<> inline h5::ds_t scatter<sn::sensor::name_all_t>(
-    hid_t fd, const std::string& path, const sn::sensor::name_all_t& obj) {
-    using namespace ::h5::generated::sn__sensor__name_all_t_;
-    h5::ds_t ds;
-    h5::mute();
-    bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
-    h5::unmute();
-    if (exists) {
-        ds = h5::open(fd, path, h5::default_dapl);
-    } else {
-        h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
-        hsize_t chunk = 64;
-        H5Pset_chunk(dcpl, 1, &chunk);
-        hsize_t cur = 0;
-        hsize_t max = H5S_UNLIMITED;
-        hid_t space = H5Screate_simple(1, &cur, &max);
-        ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
-            h5::default_lcpl, dcpl, h5::default_dapl);
+    template<> inline h5::ds_t scatter<sn::sensor::name_all_t>(
+        hid_t fd, const std::string& path, const sn::sensor::name_all_t& obj) {
+        using namespace ::h5::generated::sn__sensor__name_all_t_;
+        h5::ds_t ds;
+        h5::mute();
+        bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
+        h5::unmute();
+        if (!exists) {
+            h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
+            hsize_t chunk = 64;
+            H5Pset_chunk(dcpl, 1, &chunk);
+            hsize_t cur = 0;
+            hsize_t max = H5S_UNLIMITED;
+            hid_t space = H5Screate_simple(1, &cur, &max);
+            ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
+                h5::default_lcpl, dcpl, h5::default_dapl);
+        } else ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t row = h5::detail::next_row(ds);
+        hsize_t samples_len = obj.samples.size();
+        auto* samples_ptr = obj.samples.data();
+        row_t r{
+            obj.timestamp_ns,
+            hvl_t{samples_len, (void*)samples_ptr}
+        };
+        herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
+        (void)err;
+        return ds;
     }
-    hsize_t row = h5::detail::next_row(ds);
-    hsize_t samples_len = obj.samples.size();
-    auto* samples_ptr = obj.samples.data();
-    row_t r{
-        obj.timestamp_ns,
-        hvl_t{samples_len, (void*)samples_ptr}
-    };
-    herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
-    (void)err;
-    return ds;
-}
 } // namespace h5
 
 namespace h5 {
-template<> inline void gather<sn::sensor::name_all_t>(
-    hid_t fd, const std::string& path, sn::sensor::name_all_t& obj) {
-    using namespace ::h5::generated::sn__sensor__name_all_t_;
-    h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
-    hsize_t nrows = h5::detail::next_row(ds);
-    if (nrows == 0) return;
-    row_t r{};
-    herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
-    (void)err;
-    obj.timestamp_ns = r.timestamp_ns;
-    obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
-    H5Treclaim(compound_type(), H5S_ALL, H5P_DEFAULT, &r);
-}
+    template<> inline void gather<sn::sensor::name_all_t>(
+        hid_t fd, const std::string& path, sn::sensor::name_all_t& obj) {
+        using namespace ::h5::generated::sn__sensor__name_all_t_;
+        h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t nrows = h5::detail::next_row(ds);
+        if (nrows == 0) return;
+        row_t r{};
+        herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
+        (void)err;
+        obj.timestamp_ns = r.timestamp_ns;
+        obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
+        hid_t reclaim_space = H5Screate(H5S_SCALAR);
+        #if H5_VERSION_GE(1,12,0)
+            H5Treclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #else
+            H5Dvlen_reclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #endif
+        H5Sclose(reclaim_space);
+    }
 } // namespace h5
 
 H5CPP_REGISTER_SCATTER(sn::sensor::name_all_t);

--- a/tests/golden/h5_on_missing.expected
+++ b/tests/golden/h5_on_missing.expected
@@ -1,73 +1,70 @@
 #pragma once
 
-#include <hdf5.h>
 #include <h5cpp/all>
-
 namespace h5::generated::sn__sensor__on_missing_t_ {
-
-struct row_t {
-    unsigned long long timestamp_ns;
-    hvl_t    samples;
-};
-
-inline hid_t compound_type() {
-    static const hid_t ct = []{
-        hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
-        hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
-        H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
-        H5Tinsert(ct, "samples", HOFFSET(row_t, samples), v_samples);
+    struct row_t {
+        unsigned long long timestamp_ns;
+        hvl_t    samples;
+    };
+    inline hid_t compound_type() {
+        static const hid_t ct = []{
+            hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
+            hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
+            H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
+            H5Tinsert(ct, "samples", HOFFSET(row_t, samples), v_samples);
+            return ct;
+        }();
         return ct;
-    }();
-    return ct;
-}
-
+    }
 } // namespace h5::generated::sn__sensor__on_missing_t_
 
 namespace h5 {
-template<> inline h5::ds_t scatter<sn::sensor::on_missing_t>(
-    hid_t fd, const std::string& path, const sn::sensor::on_missing_t& obj) {
-    using namespace ::h5::generated::sn__sensor__on_missing_t_;
-    h5::ds_t ds;
-    h5::mute();
-    bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
-    h5::unmute();
-    if (!exists) {
+    template<> inline h5::ds_t scatter<sn::sensor::on_missing_t>(
+        hid_t fd, const std::string& path, const sn::sensor::on_missing_t& obj) {
+        using namespace ::h5::generated::sn__sensor__on_missing_t_;
+        h5::ds_t ds;
+        h5::mute();
+        bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
+        h5::unmute();
+        if (!exists) return ds;
+        ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t row = h5::detail::next_row(ds);
+        hsize_t samples_len = obj.samples.size();
+        auto* samples_ptr = obj.samples.data();
+        row_t r{
+            obj.timestamp_ns,
+            hvl_t{samples_len, (void*)samples_ptr}
+        };
+        herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
+        (void)err;
         return ds;
     }
-    ds = h5::open(fd, path, h5::default_dapl);
-    hsize_t row = h5::detail::next_row(ds);
-    hsize_t samples_len = obj.samples.size();
-    auto* samples_ptr = obj.samples.data();
-    row_t r{
-        obj.timestamp_ns,
-        hvl_t{samples_len, (void*)samples_ptr}
-    };
-    herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
-    (void)err;
-    return ds;
-}
 } // namespace h5
 
 namespace h5 {
-template<> inline void gather<sn::sensor::on_missing_t>(
-    hid_t fd, const std::string& path, sn::sensor::on_missing_t& obj) {
-    using namespace ::h5::generated::sn__sensor__on_missing_t_;
-    h5::mute();
-    bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
-    h5::unmute();
-    if (!exists) {
-        return;
+    template<> inline void gather<sn::sensor::on_missing_t>(
+        hid_t fd, const std::string& path, sn::sensor::on_missing_t& obj) {
+        using namespace ::h5::generated::sn__sensor__on_missing_t_;
+        h5::mute();
+        bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
+        h5::unmute();
+        if (!exists) return;
+        h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t nrows = h5::detail::next_row(ds);
+        if (nrows == 0) return;
+        row_t r{};
+        herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
+        (void)err;
+        obj.timestamp_ns = r.timestamp_ns;
+        obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
+        hid_t reclaim_space = H5Screate(H5S_SCALAR);
+        #if H5_VERSION_GE(1,12,0)
+            H5Treclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #else
+            H5Dvlen_reclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #endif
+        H5Sclose(reclaim_space);
     }
-    h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
-    hsize_t nrows = h5::detail::next_row(ds);
-    if (nrows == 0) return;
-    row_t r{};
-    herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
-    (void)err;
-    obj.timestamp_ns = r.timestamp_ns;
-    obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
-    H5Treclaim(compound_type(), H5S_ALL, H5P_DEFAULT, &r);
-}
 } // namespace h5
 
 H5CPP_REGISTER_SCATTER(sn::sensor::on_missing_t);

--- a/tests/golden/h5_scatter.expected
+++ b/tests/golden/h5_scatter.expected
@@ -1,83 +1,82 @@
 #pragma once
 
-#include <hdf5.h>
 #include <h5cpp/all>
-
 namespace h5::generated::sn__sensor__session_t_ {
-
-struct row_t {
-    unsigned long long timestamp_ns;
-    hvl_t    label;
-    hvl_t    samples;
-};
-
-inline hid_t compound_type() {
-    static const hid_t ct = []{
-        hid_t v_label = H5Tcopy(H5T_C_S1);
-        H5Tset_size(v_label, H5T_VARIABLE);
-        hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
-        hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
-        H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
-        H5Tinsert(ct, "label", HOFFSET(row_t, label), v_label);
-        H5Tinsert(ct, "samples", HOFFSET(row_t, samples), v_samples);
+    struct row_t {
+        unsigned long long timestamp_ns;
+        char*    label;
+        hvl_t    samples;
+    };
+    inline hid_t compound_type() {
+        static const hid_t ct = []{
+            hid_t v_label = H5Tcopy(H5T_C_S1);
+            H5Tset_size(v_label, H5T_VARIABLE);
+            hid_t v_samples = H5Tvlen_create(H5T_NATIVE_DOUBLE);
+            hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
+            H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
+            H5Tinsert(ct, "label", HOFFSET(row_t, label), v_label);
+            H5Tinsert(ct, "samples", HOFFSET(row_t, samples), v_samples);
+            return ct;
+        }();
         return ct;
-    }();
-    return ct;
-}
-
+    }
 } // namespace h5::generated::sn__sensor__session_t_
 
 namespace h5 {
-template<> inline h5::ds_t scatter<sn::sensor::session_t>(
-    hid_t fd, const std::string& path, const sn::sensor::session_t& obj) {
-    using namespace ::h5::generated::sn__sensor__session_t_;
-    h5::ds_t ds;
-    h5::mute();
-    bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
-    h5::unmute();
-    if (exists) {
-        ds = h5::open(fd, path, h5::default_dapl);
-    } else {
-        h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
-        hsize_t chunk = 64;
-        H5Pset_chunk(dcpl, 1, &chunk);
-        hsize_t cur = 0;
-        hsize_t max = H5S_UNLIMITED;
-        hid_t space = H5Screate_simple(1, &cur, &max);
-        ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
-            h5::default_lcpl, dcpl, h5::default_dapl);
+    template<> inline h5::ds_t scatter<sn::sensor::session_t>(
+        hid_t fd, const std::string& path, const sn::sensor::session_t& obj) {
+        using namespace ::h5::generated::sn__sensor__session_t_;
+        h5::ds_t ds;
+        h5::mute();
+        bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
+        h5::unmute();
+        if (!exists) {
+            h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
+            hsize_t chunk = 64;
+            H5Pset_chunk(dcpl, 1, &chunk);
+            hsize_t cur = 0;
+            hsize_t max = H5S_UNLIMITED;
+            hid_t space = H5Screate_simple(1, &cur, &max);
+            ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
+                h5::default_lcpl, dcpl, h5::default_dapl);
+        } else ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t row = h5::detail::next_row(ds);
+        hsize_t label_len = obj.label.size();
+        const char* label_ptr = obj.label.c_str();
+        hsize_t samples_len = obj.samples.size();
+        auto* samples_ptr = obj.samples.data();
+        row_t r{
+            obj.timestamp_ns,
+            (char*)label_ptr,
+            hvl_t{samples_len, (void*)samples_ptr}
+        };
+        herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
+        (void)err;
+        return ds;
     }
-    hsize_t row = h5::detail::next_row(ds);
-    hsize_t label_len = obj.label.size();
-    const char* label_ptr = obj.label.c_str();
-    hsize_t samples_len = obj.samples.size();
-    auto* samples_ptr = obj.samples.data();
-    row_t r{
-        obj.timestamp_ns,
-        hvl_t{label_len, (void*)label_ptr},
-        hvl_t{samples_len, (void*)samples_ptr}
-    };
-    herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
-    (void)err;
-    return ds;
-}
 } // namespace h5
 
 namespace h5 {
-template<> inline void gather<sn::sensor::session_t>(
-    hid_t fd, const std::string& path, sn::sensor::session_t& obj) {
-    using namespace ::h5::generated::sn__sensor__session_t_;
-    h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
-    hsize_t nrows = h5::detail::next_row(ds);
-    if (nrows == 0) return;
-    row_t r{};
-    herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
-    (void)err;
-    obj.timestamp_ns = r.timestamp_ns;
-    obj.label.assign(static_cast<char*>(r.label.p), r.label.len);
-    obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
-    H5Treclaim(compound_type(), H5S_ALL, H5P_DEFAULT, &r);
-}
+    template<> inline void gather<sn::sensor::session_t>(
+        hid_t fd, const std::string& path, sn::sensor::session_t& obj) {
+        using namespace ::h5::generated::sn__sensor__session_t_;
+        h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t nrows = h5::detail::next_row(ds);
+        if (nrows == 0) return;
+        row_t r{};
+        herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
+        (void)err;
+        obj.timestamp_ns = r.timestamp_ns;
+        if (r.label) obj.label.assign(r.label);
+        obj.samples.assign(static_cast<double*>(r.samples.p), static_cast<double*>(r.samples.p) + r.samples.len);
+        hid_t reclaim_space = H5Screate(H5S_SCALAR);
+        #if H5_VERSION_GE(1,12,0)
+            H5Treclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #else
+            H5Dvlen_reclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #endif
+        H5Sclose(reclaim_space);
+    }
 } // namespace h5
 
 H5CPP_REGISTER_SCATTER(sn::sensor::session_t);

--- a/tests/golden/h5_scatter_attrs.expected
+++ b/tests/golden/h5_scatter_attrs.expected
@@ -1,83 +1,82 @@
 #pragma once
 
-#include <hdf5.h>
 #include <h5cpp/all>
-
 namespace h5::generated::sn__sensor__annotated_t_ {
-
-struct row_t {
-    unsigned long long timestamp_ns;
-    hvl_t    label;
-    hvl_t    readings;
-};
-
-inline hid_t compound_type() {
-    static const hid_t ct = []{
-        hid_t v_label = H5Tcopy(H5T_C_S1);
-        H5Tset_size(v_label, H5T_VARIABLE);
-        hid_t v_readings = H5Tvlen_create(H5T_NATIVE_DOUBLE);
-        hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
-        H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
-        H5Tinsert(ct, "label", HOFFSET(row_t, label), v_label);
-        H5Tinsert(ct, "data", HOFFSET(row_t, readings), v_readings);
+    struct row_t {
+        unsigned long long timestamp_ns;
+        char*    label;
+        hvl_t    readings;
+    };
+    inline hid_t compound_type() {
+        static const hid_t ct = []{
+            hid_t v_label = H5Tcopy(H5T_C_S1);
+            H5Tset_size(v_label, H5T_VARIABLE);
+            hid_t v_readings = H5Tvlen_create(H5T_NATIVE_DOUBLE);
+            hid_t ct = H5Tcreate(H5T_COMPOUND, sizeof(row_t));
+            H5Tinsert(ct, "timestamp_ns", HOFFSET(row_t, timestamp_ns), H5T_NATIVE_ULLONG);
+            H5Tinsert(ct, "label", HOFFSET(row_t, label), v_label);
+            H5Tinsert(ct, "data", HOFFSET(row_t, readings), v_readings);
+            return ct;
+        }();
         return ct;
-    }();
-    return ct;
-}
-
+    }
 } // namespace h5::generated::sn__sensor__annotated_t_
 
 namespace h5 {
-template<> inline h5::ds_t scatter<sn::sensor::annotated_t>(
-    hid_t fd, const std::string& path, const sn::sensor::annotated_t& obj) {
-    using namespace ::h5::generated::sn__sensor__annotated_t_;
-    h5::ds_t ds;
-    h5::mute();
-    bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
-    h5::unmute();
-    if (exists) {
-        ds = h5::open(fd, path, h5::default_dapl);
-    } else {
-        h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
-        hsize_t chunk = 64;
-        H5Pset_chunk(dcpl, 1, &chunk);
-        hsize_t cur = 0;
-        hsize_t max = H5S_UNLIMITED;
-        hid_t space = H5Screate_simple(1, &cur, &max);
-        ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
-            h5::default_lcpl, dcpl, h5::default_dapl);
+    template<> inline h5::ds_t scatter<sn::sensor::annotated_t>(
+        hid_t fd, const std::string& path, const sn::sensor::annotated_t& obj) {
+        using namespace ::h5::generated::sn__sensor__annotated_t_;
+        h5::ds_t ds;
+        h5::mute();
+        bool exists = H5Lexists(fd, path.c_str(), H5P_DEFAULT) > 0;
+        h5::unmute();
+        if (!exists) {
+            h5::dcpl_t dcpl{H5Pcreate(H5P_DATASET_CREATE)};
+            hsize_t chunk = 64;
+            H5Pset_chunk(dcpl, 1, &chunk);
+            hsize_t cur = 0;
+            hsize_t max = H5S_UNLIMITED;
+            hid_t space = H5Screate_simple(1, &cur, &max);
+            ds = h5::createds(fd, path, compound_type(), h5::sp_t{space},
+                h5::default_lcpl, dcpl, h5::default_dapl);
+        } else ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t row = h5::detail::next_row(ds);
+        hsize_t label_len = obj.label.size();
+        const char* label_ptr = obj.label.c_str();
+        hsize_t readings_len = obj.readings.size();
+        auto* readings_ptr = obj.readings.data();
+        row_t r{
+            obj.timestamp_ns,
+            (char*)label_ptr,
+            hvl_t{readings_len, (void*)readings_ptr}
+        };
+        herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
+        (void)err;
+        return ds;
     }
-    hsize_t row = h5::detail::next_row(ds);
-    hsize_t label_len = obj.label.size();
-    const char* label_ptr = obj.label.c_str();
-    hsize_t readings_len = obj.readings.size();
-    auto* readings_ptr = obj.readings.data();
-    row_t r{
-        obj.timestamp_ns,
-        hvl_t{label_len, (void*)label_ptr},
-        hvl_t{readings_len, (void*)readings_ptr}
-    };
-    herr_t err = h5::detail::write_one_row(ds, compound_type(), row, &r);
-    (void)err;
-    return ds;
-}
 } // namespace h5
 
 namespace h5 {
-template<> inline void gather<sn::sensor::annotated_t>(
-    hid_t fd, const std::string& path, sn::sensor::annotated_t& obj) {
-    using namespace ::h5::generated::sn__sensor__annotated_t_;
-    h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
-    hsize_t nrows = h5::detail::next_row(ds);
-    if (nrows == 0) return;
-    row_t r{};
-    herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
-    (void)err;
-    obj.timestamp_ns = r.timestamp_ns;
-    obj.label.assign(static_cast<char*>(r.label.p), r.label.len);
-    obj.readings.assign(static_cast<double*>(r.readings.p), static_cast<double*>(r.readings.p) + r.readings.len);
-    H5Treclaim(compound_type(), H5S_ALL, H5P_DEFAULT, &r);
-}
+    template<> inline void gather<sn::sensor::annotated_t>(
+        hid_t fd, const std::string& path, sn::sensor::annotated_t& obj) {
+        using namespace ::h5::generated::sn__sensor__annotated_t_;
+        h5::ds_t ds = h5::open(fd, path, h5::default_dapl);
+        hsize_t nrows = h5::detail::next_row(ds);
+        if (nrows == 0) return;
+        row_t r{};
+        herr_t err = h5::detail::read_one_row(ds, compound_type(), nrows - 1, &r);
+        (void)err;
+        obj.timestamp_ns = r.timestamp_ns;
+        if (r.label) obj.label.assign(r.label);
+        obj.readings.assign(static_cast<double*>(r.readings.p), static_cast<double*>(r.readings.p) + r.readings.len);
+        hid_t reclaim_space = H5Screate(H5S_SCALAR);
+        #if H5_VERSION_GE(1,12,0)
+            H5Treclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #else
+            H5Dvlen_reclaim(compound_type(), reclaim_space, H5P_DEFAULT, &r);
+        #endif
+        H5Sclose(reclaim_space);
+    }
 } // namespace h5
 
 H5CPP_REGISTER_SCATTER(sn::sensor::annotated_t);

--- a/tests/golden/h5_serialize_full.expected
+++ b/tests/golden/h5_serialize_full.expected
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <hdf5.h>
 #include <h5cpp/all>
-
 namespace h5 {
     template<> hid_t inline register_struct<sn::sensor::serialize_full_t>(){
 


### PR DESCRIPTION
## Summary
- Refreshes all 11 `tests/golden/h5_*.expected` baselines to match the producer output emitted after the #34 merge (commits 57a7030, 268e7b9, ade1c56 — squashed into staging as d30f7a0/4a4ac7f).
- Changes captured: drop `#include <hdf5.h>` (transitive via `<h5cpp/all>`), namespace-aligned indentation inside `namespace h5`, `char*` storage for VLEN strings in `row_t`, and the `H5Dvlen_reclaim` reclaim pattern.
- No source/code changes — goldens only.

## Test plan
- [x] Local `ctest` on Ubuntu / clang-19 — 73/73 pass